### PR TITLE
Fix HTML entity and update alt text in components

### DIFF
--- a/src/components/Stanzas.tsx
+++ b/src/components/Stanzas.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import SectionBlock from "@/components/SectionBlock";
 import { stanzas } from "@/data/stanzas";
@@ -11,7 +9,7 @@ const Stanzas: React.FC = () => {
         <SectionBlock
           key={section.id}
           image={section.image}
-          alt={section.alt}
+          alt={section.theme}
           flip={section.flip}
         >
           {section.lines.map((line, index) => (


### PR DESCRIPTION
Correct HTML entity for apostrophes in the Hero and stanzaGroups components and refactor the alt text in the Stanzas component to utilize the theme property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `alt` property in the Stanzas component to use the section's theme instead of its alt value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->